### PR TITLE
feat(worker): add SessionStatus enum

### DIFF
--- a/apps/worker/alembic/versions/b9f712cd6fa9_initial_schema_creation_with_sqlmodel.py
+++ b/apps/worker/alembic/versions/b9f712cd6fa9_initial_schema_creation_with_sqlmodel.py
@@ -83,7 +83,7 @@ def upgrade() -> None:
     op.create_table(
         "session",
         sa.Column("browser_provider_session_id", sa.VARCHAR(), nullable=True),
-        sa.Column("status", sa.VARCHAR(), nullable=False),
+        sa.Column("status", sa.VARCHAR(), nullable=False, server_default="starting"),
         sa.Column("session_url", sa.VARCHAR(), nullable=True),
         sa.Column("created_at", sa.DATETIME(), nullable=False),
         sa.Column("ended_at", sa.DATETIME(), nullable=True),

--- a/apps/worker/alembic/versions/b9f712cd6fa9_initial_schema_creation_with_sqlmodel.py
+++ b/apps/worker/alembic/versions/b9f712cd6fa9_initial_schema_creation_with_sqlmodel.py
@@ -91,6 +91,9 @@ def upgrade() -> None:
         sa.Column("run_id", sa.CHAR(32), nullable=False),
         sa.ForeignKeyConstraint(["run_id"], ["run.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "status in ('starting','active','paused','ended')", name="ck_session_status"
+        ),
     )
     op.create_index(op.f("ix_session_run_id"), "session", ["run_id"], unique=False)
     # ### end Alembic commands ###

--- a/apps/worker/app/models.py
+++ b/apps/worker/app/models.py
@@ -59,7 +59,7 @@ class SessionBase(SQLModel):
     browser_provider_session_id: str | None = None
     status: SessionStatus = Field(
         default=SessionStatus.STARTING,
-        sa_column=Column(sa.VARCHAR(), server_default="starting"),
+        sa_column=Column(sa.VARCHAR(), server_default=SessionStatus.STARTING.value),
     )
     session_url: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/apps/worker/app/services/run/service.py
+++ b/apps/worker/app/services/run/service.py
@@ -166,7 +166,7 @@ class RunService:
             run_id=run_id,
             browser_provider_session_id=browser_session_id,
             session_url=session_url,
-            status=SessionStatus.ACTIVE.value,
+            status=SessionStatus.ACTIVE,
         )
         await self.repository.create_session(session, db_session)
 

--- a/apps/worker/app/services/run/service.py
+++ b/apps/worker/app/services/run/service.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Run, RunCreate, RunStatus
+from app.models import Run, RunCreate, RunStatus, SessionStatus
 from app.models import Session as SessionModel
 from app.services.run.errors import (
     MissingSessionURLError,
@@ -166,7 +166,7 @@ class RunService:
             run_id=run_id,
             browser_provider_session_id=browser_session_id,
             session_url=session_url,
-            status="running",
+            status=SessionStatus.ACTIVE.value,
         )
         await self.repository.create_session(session, db_session)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Standardized session lifecycle statuses: Starting, Active, Paused, Ended.
  - New sessions default to “Starting” if no status is provided.
  - API responses consistently return status values (enum-backed) for easier integration.

- Refactor
  - Unified status handling across services for more reliable session creation and transitions.
  - Sessions created during run finalization now initialize as Active when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->