### PR TITLE
feat(worker): include session URL in run creation response

### DIFF
--- a/apps/worker/app/models.py
+++ b/apps/worker/app/models.py
@@ -239,6 +239,20 @@ class RunRead(PydanticBaseModel):
     updated_at: datetime
 
 
+class RunCreateResponse(PydanticBaseModel):
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+    id: UUID
+    flow_id: UUID
+    user_id: UUID
+    status: RunStatus
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    error: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    session_url: str | None = None
+
+
 class RunUpdate(PydanticBaseModel):
     model_config = ConfigDict(from_attributes=True)
     result_uri: str | None = None

--- a/apps/worker/app/models.py
+++ b/apps/worker/app/models.py
@@ -4,7 +4,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import ConfigDict, model_validator
+from pydantic import ConfigDict, HttpUrl, model_validator
 from pydantic import Field as PydField
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy import Index
@@ -250,7 +250,7 @@ class RunCreateResponse(PydanticBaseModel):
     error: str | None = None
     created_at: datetime
     updated_at: datetime
-    session_url: str | None = None
+    session_url: HttpUrl | None = None
 
 
 class RunUpdate(PydanticBaseModel):

--- a/apps/worker/app/routers/runs.py
+++ b/apps/worker/app/routers/runs.py
@@ -22,6 +22,7 @@ from app.models import (
 from app.services.flow.errors import FlowAccessDeniedError, FlowNotFoundError
 from app.services.run.errors import (
     MissingSessionURLError,
+    RunFinalizationError,
     SessionCreationFailedError,
 )
 from app.services.run.service import RunService
@@ -87,7 +88,7 @@ async def create_run(
             status_code=HTTPStatus.BAD_REQUEST,
             detail="Invalid request data",
         ) from e
-    except SessionCreationFailedError as e:
+    except (RunFinalizationError, SessionCreationFailedError) as e:
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail=str(e),

--- a/apps/worker/app/routers/runs.py
+++ b/apps/worker/app/routers/runs.py
@@ -12,6 +12,7 @@ from app.models import (
     EventRead,
     RunContinue,
     RunCreate,
+    RunCreateResponse,
     RunRead,
     RunUpdate,
     SessionRead,
@@ -35,16 +36,31 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/runs", response_model=RunRead, status_code=HTTPStatus.CREATED)
+@router.post("/runs", response_model=RunCreateResponse, status_code=HTTPStatus.CREATED)
 async def create_run(
     request: RunCreate,
     current_user: User = current_user_dependency,
     session: AsyncSession = db_dependency,
 ):
-    """Create a new run, initialize Steel.dev session, and return run details."""
+    """Create a new run, initialize browser session, return run with session URL."""
     service = RunService()
     try:
-        return await service.create_run_with_user(request, current_user, session)
+        run, session_url = await service.create_run_with_user(
+            request, current_user, session
+        )
+
+        return RunCreateResponse(
+            id=run.id,
+            flow_id=run.flow_id,
+            user_id=run.user_id,
+            status=run.status,
+            started_at=run.started_at,
+            ended_at=run.ended_at,
+            error=run.error,
+            created_at=run.created_at,
+            updated_at=run.updated_at,
+            session_url=session_url,
+        )
     except FlowNotFoundError as e:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,

--- a/apps/worker/app/services/run/errors.py
+++ b/apps/worker/app/services/run/errors.py
@@ -21,3 +21,13 @@ class RunNotFoundError(RunError):
 
     def __init__(self, run_id: str) -> None:
         super().__init__(f"Run {run_id} not found")
+
+
+class RunFinalizationError(RunError):
+    """Raised when a run cannot be finalized after session creation."""
+
+    def __init__(self, run_id: str, session_id: str | None = None) -> None:
+        message = f"Run {run_id} could not be finalized"
+        if session_id:
+            message = f"{message} for session {session_id}"
+        super().__init__(message)

--- a/apps/worker/app/services/run/service.py
+++ b/apps/worker/app/services/run/service.py
@@ -44,8 +44,11 @@ class RunService:
 
     async def create_run_with_user(
         self, request: RunCreate, user: User, session: AsyncSession
-    ) -> Run:
-        """Create a new run with authenticated user."""
+    ) -> tuple[Run, str]:
+        """Create a new run with authenticated user.
+        Returns:
+            tuple: (run, session_url) where session_url is the browser session URL
+        """
         # Validate that the flow exists and user has access to it
         await self._validate_flow_exists_and_access(request.flow_id, user, session)
 
@@ -96,7 +99,7 @@ class RunService:
             await session.rollback()
             raise
         else:
-            return run
+            return run, session_url
 
     async def list_runs_for_user(
         self, user_id: UUID, session: AsyncSession, skip: int = 0, limit: int = 100

--- a/apps/worker/app/services/run/service.py
+++ b/apps/worker/app/services/run/service.py
@@ -175,8 +175,7 @@ class RunService:
         # Update run
         run = await self.repository.get_by_id(session, run_id)
         if not run:
-            # Should not happen: run was just created in the same transaction
-            raise SessionCreationFailedError
+            self._handle_run_finalization_failure(run_id, browser_session_id)
         run.status = RunStatus.RUNNING
         run.started_at = datetime.now(UTC)
         run.updated_at = datetime.now(UTC)

--- a/apps/worker/tests/contract/test_runs_post.py
+++ b/apps/worker/tests/contract/test_runs_post.py
@@ -20,6 +20,8 @@ class TestRunsPostContract(BaseTestClass):
         data = response.json()
         assert "id" in data
         assert data["status"] == "running"
+        assert "session_url" in data
+        assert data["session_url"] is not None
         assert data["flow_id"] == "550e8400-e29b-41d4-a716-446655440000"
         assert data["user_id"] == "550e8400-e29b-41d4-a716-446655440000"
 
@@ -74,6 +76,8 @@ class TestRunsPostContract(BaseTestClass):
 
         # Verify the run was created and is in running state
         assert data["status"] == "running"
+        assert "session_url" in data
+        assert data["session_url"] is not None
 
         # Check that sessions were created for this run
         sessions_response = self.client.get(

--- a/apps/worker/tests/contract/test_runs_post.py
+++ b/apps/worker/tests/contract/test_runs_post.py
@@ -22,6 +22,9 @@ class TestRunsPostContract(BaseTestClass):
         assert data["status"] == "running"
         assert "session_url" in data
         assert data["session_url"] is not None
+        assert data["session_url"].startswith("http"), (
+            "session_url should be an HTTP(S) URL"
+        )
         assert data["flow_id"] == "550e8400-e29b-41d4-a716-446655440000"
         assert data["user_id"] == "550e8400-e29b-41d4-a716-446655440000"
 
@@ -78,6 +81,9 @@ class TestRunsPostContract(BaseTestClass):
         assert data["status"] == "running"
         assert "session_url" in data
         assert data["session_url"] is not None
+        assert data["session_url"].startswith("http"), (
+            "session_url should be an HTTP(S) URL"
+        )
 
         # Check that sessions were created for this run
         sessions_response = self.client.get(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - POST /runs responses now include a session URL and expose lifecycle fields (status, started_at, ended_at, error).
- Bug Fixes
  - Improved handling and surfacing of run-finalization failures so backend errors are more reliably reported as server errors.
- Tests
  - Contract tests updated to assert presence and format of session_url in POST /runs responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->