### PR TITLE
fix(worker): e2e seeding non-blocking and update session URL field

### DIFF
--- a/apps/worker/app/bootstrap/e2e_data.py
+++ b/apps/worker/app/bootstrap/e2e_data.py
@@ -1,52 +1,75 @@
 import asyncio
+import logging
 
 from sqlalchemy import select
 
 from app.db import AsyncSessionLocal
 from app.models import Flow, User, UserRole
 
+logger = logging.getLogger(__name__)
+_seed_tasks: set[asyncio.Task[None]] = set()
+
 
 async def seed_e2e_flows() -> None:
-    """Seed sample flows for E2E testing."""
-    async with AsyncSessionLocal() as session:
-        # Ensure there is at least one admin (created by first signup)
-        admin_id = None
-        max_attempts = 10
-        delay_seconds = 0.5
+    """Seed sample flows for E2E testing without blocking startup."""
 
-        for attempt in range(max_attempts):
-            admin_row = await session.execute(
-                select(User.id).where(User.role == UserRole.ADMIN).limit(1)
-            )
-            admin_id = admin_row.scalar_one_or_none()
-            if admin_id:
-                break
-            if attempt < max_attempts - 1:
+    async def _wait_for_admin_and_seed() -> None:
+        async with AsyncSessionLocal() as session:
+            # Bail early if flows already exist
+            existing_flow = await session.execute(select(Flow.id).limit(1))
+            if existing_flow.scalar_one_or_none():
+                logger.debug("E2E flows already seeded; skipping")
+                return
+
+            admin_id = None
+            max_attempts = 120
+            delay_seconds = 1.0
+
+            for attempt in range(max_attempts):
+                admin_row = await session.execute(
+                    select(User.id).where(User.role == UserRole.ADMIN).limit(1)
+                )
+                admin_id = admin_row.scalar_one_or_none()
+                if admin_id:
+                    break
+                logger.debug(
+                    "Waiting for admin user before seeding flows (attempt %s/%s)",
+                    attempt + 1,
+                    max_attempts,
+                )
                 await asyncio.sleep(delay_seconds)
 
-        if not admin_id:
-            # No admin yet; flows will be created after the first signup
-            return
+            if not admin_id:
+                logger.warning(
+                    "E2E flow seeding skipped - admin user not found after waiting"
+                )
+                return
 
-        # Only seed if there are no flows yet
-        any_flow = await session.execute(select(Flow.id).limit(1))
-        if any_flow.scalar_one_or_none():
-            return
+            # Double-check no flows were added while we were waiting
+            any_flow = await session.execute(select(Flow.id).limit(1))
+            if any_flow.scalar_one_or_none():
+                logger.debug("E2E flows seeded by another process; skipping")
+                return
 
-        session.add_all(
-            [
-                Flow(
-                    key="test-flow",
-                    name="Test Flow",
-                    description="A test flow for E2E validation",
-                    created_by=admin_id,
-                ),
-                Flow(
-                    key="hitl-flow",
-                    name="HITL Flow",
-                    description="Human-in-the-loop demo flow",
-                    created_by=admin_id,
-                ),
-            ]
-        )
-        await session.commit()
+            session.add_all(
+                [
+                    Flow(
+                        key="test-flow",
+                        name="Test Flow",
+                        description="A test flow for E2E validation",
+                        created_by=admin_id,
+                    ),
+                    Flow(
+                        key="hitl-flow",
+                        name="HITL Flow",
+                        description="Human-in-the-loop demo flow",
+                        created_by=admin_id,
+                    ),
+                ]
+            )
+            await session.commit()
+            logger.info("Seeded default E2E flows")
+
+    task = asyncio.create_task(_wait_for_admin_and_seed())
+    _seed_tasks.add(task)
+    task.add_done_callback(_seed_tasks.discard)

--- a/apps/worker/app/bootstrap/e2e_data.py
+++ b/apps/worker/app/bootstrap/e2e_data.py
@@ -37,6 +37,8 @@ async def seed_e2e_flows() -> None:
                     attempt + 1,
                     max_attempts,
                 )
+                # End the current transaction to avoid long-lived idle-in-transaction
+                await session.rollback()
                 await asyncio.sleep(delay_seconds)
 
             if not admin_id:
@@ -46,6 +48,7 @@ async def seed_e2e_flows() -> None:
                 return
 
             # Double-check no flows were added while we were waiting
+            await session.rollback()
             any_flow = await session.execute(select(Flow.id).limit(1))
             if any_flow.scalar_one_or_none():
                 logger.debug("E2E flows seeded by another process; skipping")

--- a/apps/worker/app/services/run/service.py
+++ b/apps/worker/app/services/run/service.py
@@ -70,7 +70,7 @@ class RunService:
                 )
                 self._fail_session_creation()
 
-            session_url = session_data.get("sessionViewerUrl")
+            session_url = session_data.get("debugUrl")
             browser_session_id = session_data.get("id")
 
             if not session_url:

--- a/apps/worker/app/services/steel_service.py
+++ b/apps/worker/app/services/steel_service.py
@@ -58,9 +58,9 @@ class SteelService:
                 return None
 
             session_data = response.json()
-            session_url = session_data.get("sessionViewerUrl")
+            session_url = session_data.get("debugUrl")
             if not session_url:
-                logger.error("Steel session created but missing 'sessionViewerUrl'")
+                logger.error("Steel session created but missing 'debugUrl'")
                 return None
             logger.info(
                 "Successfully created Steel session: %s",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected session link handling to use the debug URL, ensuring reliable links in run details and Steel sessions. Error messages now reference the correct field when unavailable.

- Refactor
  - Improved startup responsiveness by moving initial data seeding to a non-blocking background task.
  - Added safeguards to avoid duplicate seeding and enhanced logging around wait/skip conditions for greater observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->