### PR TITLE
fix(worker): specify enum column for run status

### DIFF
--- a/apps/worker/alembic/versions/0f0c72d0b94f_initial_schema.py
+++ b/apps/worker/alembic/versions/0f0c72d0b94f_initial_schema.py
@@ -1,8 +1,8 @@
 """initial schema
 
-Revision ID: 685f547cd036
+Revision ID: 0f0c72d0b94f
 Revises:
-Create Date: 2025-10-01 14:28:30.313069
+Create Date: 2025-10-01 22:44:36.429328
 
 """
 
@@ -15,7 +15,7 @@ from sqlalchemy.dialects import sqlite
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "685f547cd036"
+revision: str = "0f0c72d0b94f"
 down_revision: str | Sequence[str] | None = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
@@ -89,6 +89,7 @@ def upgrade() -> None:
                 "canceled",
                 name="runstatus",
             ),
+            server_default="pending",
             nullable=False,
         ),
         sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),

--- a/apps/worker/app/models.py
+++ b/apps/worker/app/models.py
@@ -74,7 +74,17 @@ class EventType(str, Enum):
 
 
 class RunBase(SQLModel):
-    status: RunStatus = RunStatus.PENDING
+    status: RunStatus = Field(
+        default=RunStatus.PENDING,
+        sa_column=Column(
+            SQLEnum(
+                RunStatus,
+                values_callable=lambda enum: [member.value for member in enum],
+            ),
+            server_default=RunStatus.PENDING.value,
+            nullable=False,
+        ),
+    )
     started_at: datetime | None = Field(
         default=None,
         sa_column=Column(DateTime(timezone=True), nullable=True),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New runs now consistently start in a Pending status, eliminating occasional missing/invalid statuses and improving reliability of run tracking and status displays.

* **Chores**
  * Aligned backend schema with enforced status defaults to improve consistency across environments.
  * Updated internal metadata for the latest schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->